### PR TITLE
feat: allow using authorization query parameter

### DIFF
--- a/src/Security/JWT/Extractor/AuthorizationHeaderTokenExtractor.php
+++ b/src/Security/JWT/Extractor/AuthorizationHeaderTokenExtractor.php
@@ -6,11 +6,15 @@ namespace Freddie\Security\JWT\Extractor;
 
 use Psr\Http\Message\ServerRequestInterface;
 
+use function strlen;
+use function str_starts_with;
+use function substr;
+
 final class AuthorizationHeaderTokenExtractor implements PSR7TokenExtractorInterface
 {
     public function __construct(
         private string $name = 'Authorization',
-        private string $prefix = 'Bearer',
+        private string $prefix = 'Bearer ',
     ) {
     }
 
@@ -21,12 +25,12 @@ final class AuthorizationHeaderTokenExtractor implements PSR7TokenExtractorInter
         }
 
         $authorizationHeader = $request->getHeaderLine($this->name);
-        $headerParts = explode(' ', $authorizationHeader);
-
-        if (!(2 === count($headerParts) && 0 === strcasecmp($headerParts[0], $this->prefix))) {
+        if (!str_starts_with($authorizationHeader, $this->prefix)) {
             return null;
         }
 
-        return $headerParts[1];
+        $token = substr($authorizationHeader, strlen($this->prefix));
+
+        return strlen($token) < 41 ? null : $token;
     }
 }

--- a/src/Security/JWT/Extractor/ChainTokenExtractor.php
+++ b/src/Security/JWT/Extractor/ChainTokenExtractor.php
@@ -18,6 +18,7 @@ final class ChainTokenExtractor implements PSR7TokenExtractorInterface
         private iterable $tokenExtractors = [
             new CookieTokenExtractor(),
             new AuthorizationHeaderTokenExtractor(),
+            new QueryTokenExtractor(),
         ],
     ) {
     }

--- a/src/Security/JWT/Extractor/CookieTokenExtractor.php
+++ b/src/Security/JWT/Extractor/CookieTokenExtractor.php
@@ -7,8 +7,9 @@ namespace Freddie\Security\JWT\Extractor;
 use Psr\Http\Message\ServerRequestInterface;
 
 use function array_map;
-use function Freddie\nullify;
 use function implode;
+use function is_string;
+use function strlen;
 
 final class CookieTokenExtractor implements PSR7TokenExtractorInterface
 {
@@ -36,6 +37,10 @@ final class CookieTokenExtractor implements PSR7TokenExtractorInterface
             ),
         );
 
-        return nullify($token);
+        if (!is_string($token) || strlen($token) < 41) {
+            return null;
+        }
+
+        return $token;
     }
 }

--- a/src/Security/JWT/Extractor/QueryTokenExtractor.php
+++ b/src/Security/JWT/Extractor/QueryTokenExtractor.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Freddie\Security\JWT\Extractor;
+
+use Freddie\Helper\FlatQueryParser;
+use Psr\Http\Message\ServerRequestInterface;
+
+use function is_string;
+use function strlen;
+use function BenTools\QueryString\query_string;
+
+final class QueryTokenExtractor implements PSR7TokenExtractorInterface
+{
+    public function __construct(
+        private string $name = 'authorization',
+    ) {
+    }
+
+    public function extract(ServerRequestInterface $request): ?string
+    {
+        $qs = query_string($request->getUri(), new FlatQueryParser());
+        $authorizationQuery = $qs->getParam($this->name);
+        if (!is_string($authorizationQuery) || strlen($authorizationQuery) < 41) {
+            return null;
+        }
+
+        return $authorizationQuery;
+    }
+}

--- a/tests/Unit/Security/JWT/Extractor/AuthorizationHeaderExtractorTest.php
+++ b/tests/Unit/Security/JWT/Extractor/AuthorizationHeaderExtractorTest.php
@@ -12,7 +12,9 @@ it('extracts token from authorization header', function (array $headers, ?string
     $request = new ServerRequest('GET', '/.well-known/mercure', $headers);
     expect($extractor->extract($request))->toBe($expected);
 })->with(function () {
-    yield [['Authorization' => 'Bearer foobar'], 'foobar'];
+    $validToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30._esyynAyo2Z6PyGe0mM_SuQ3c-C7sMQJ1YxVLvlj80A';
+
+    yield [['Authorization' => 'Bearer ' . $validToken], $validToken];
     yield [['Authorization' => 'foobar'], null];
     yield [['Authorization' => ''], null];
     yield [[], null];

--- a/tests/Unit/Security/JWT/Extractor/ChainTokenExtractorTest.php
+++ b/tests/Unit/Security/JWT/Extractor/ChainTokenExtractorTest.php
@@ -15,24 +15,60 @@ it('extracts token either from cookies or authorization header', function (
     $extractor = new ChainTokenExtractor();
     expect($extractor->extract($request))->toBe($expected);
 })->with(function () {
+    $validToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30._esyynAyo2Z6PyGe0mM_SuQ3c-C7sMQJ1YxVLvlj80A';
+
+    yield [
+        'request' => new ServerRequest('GET', '/.well-known/mercure', [
+            'Cookie' => 'mercureAuthorization=' . $validToken,
+        ]),
+        'expected' => $validToken,
+    ];
+    yield [
+        'request' => new ServerRequest('GET', '/.well-known/mercure?authorization=' . $validToken),
+        'expected' => $validToken,
+    ];
+    yield [
+        'request' => new ServerRequest('GET', '/.well-known/mercure', [
+            'Cookie' => 'mercureAuthorization=' . $validToken,
+            'Authorization' => 'Bearer foo',
+        ]),
+        'expected' => $validToken,
+    ];
+    yield [
+        'request' => new ServerRequest('GET', '/.well-known/mercure', [
+            'Cookie' => 'mercureAuthorization=foo',
+            'Authorization' => 'Bearer ' . $validToken,
+        ]),
+        'expected' => $validToken,
+    ];
+    yield [
+        'request' => new ServerRequest('GET', '/.well-known/mercure', [
+            'Authorization' => 'Bearer ' . $validToken,
+        ]),
+        'expected' => $validToken,
+    ];
     yield [
         'request' => new ServerRequest('GET', '/.well-known/mercure', [
             'Cookie' => 'mercureAuthorization=foobar',
         ]),
-        'expected' => 'foobar',
+        'expected' => null,
     ];
     yield [
         'request' => new ServerRequest('GET', '/.well-known/mercure', [
             'Cookie' => 'mercureAuthorization=foo',
             'Authorization' => 'Bearer bar',
         ]),
-        'expected' => 'foo',
+        'expected' => null,
     ];
     yield [
         'request' => new ServerRequest('GET', '/.well-known/mercure', [
             'Authorization' => 'Bearer foobar',
         ]),
-        'expected' => 'foobar',
+        'expected' => null,
+    ];
+    yield [
+        'request' => new ServerRequest('GET', '/.well-known/mercure?authorization=foobar'),
+        'expected' => null,
     ];
     yield [
         'request' => new ServerRequest('GET', '/.well-known/mercure'),

--- a/tests/Unit/Security/JWT/Extractor/CookieExtractorTest.php
+++ b/tests/Unit/Security/JWT/Extractor/CookieExtractorTest.php
@@ -8,17 +8,23 @@ use Freddie\Security\JWT\Extractor\CookieTokenExtractor;
 use React\Http\Message\ServerRequest;
 
 it('extracts token from cookies', function () {
+    $validToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30._esyynAyo2Z6PyGe0mM_SuQ3c-C7sMQJ1YxVLvlj80A';
+
     $extractor = new CookieTokenExtractor();
     $request = new ServerRequest('GET', '/.well-known/mercure', [
-        'Cookie' => 'foo=bar; mercureAuthorization=foobar; bar=foo',
+        'Cookie' => 'foo=bar; mercureAuthorization=' . $validToken . '; bar=foo',
     ]);
-    expect($extractor->extract($request))->toBe('foobar');
+    expect($extractor->extract($request))->toBe($validToken);
 });
 
 it('is compliant with the split-cookie strategy', function () {
+    $jwt_hp = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30';
+    $jwt_s = '_esyynAyo2Z6PyGe0mM_SuQ3c-C7sMQJ1YxVLvlj80A';
+    $validToken = $jwt_hp . '.' . $jwt_s;
+
     $extractor = new CookieTokenExtractor(['jwt_hp', 'jwt_s']);
     $request = new ServerRequest('GET', '/.well-known/mercure', [
-        'Cookie' => 'foo=bar; jwt_hp=foobar; bar=foo; jwt_s=signed',
+        'Cookie' => 'foo=bar; jwt_hp=' . $jwt_hp . '; bar=foo; jwt_s=' . $jwt_s,
     ]);
-    expect($extractor->extract($request))->toBe('foobar.signed');
+    expect($extractor->extract($request))->toBe($validToken);
 });

--- a/tests/Unit/Security/JWT/Extractor/QueryTokenExtractorTest.php
+++ b/tests/Unit/Security/JWT/Extractor/QueryTokenExtractorTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Freddie\Tests\Unit\Security\JWT\Extractor;
+
+use Freddie\Security\JWT\Extractor\QueryTokenExtractor;
+use React\Http\Message\ServerRequest;
+
+it('extracts token from authorization query parameter', function (string $uri, ?string $expected) {
+    $extractor = new QueryTokenExtractor();
+    $request = new ServerRequest('GET', $uri);
+    expect($extractor->extract($request))->toBe($expected);
+})->with(function () {
+    $validToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30._esyynAyo2Z6PyGe0mM_SuQ3c-C7sMQJ1YxVLvlj80A';
+
+    yield ['/.well-known/mercure?authorization=' . $validToken, $validToken];
+    yield ['/.well-known/mercure?authorization=foo', null];
+    yield ['/.well-known/mercure?authorization', null];
+    yield ['/.well-known/mercure', null];
+});


### PR DESCRIPTION
This PR implements query authorization which was recently added to mercure spec.

some performance improves are also added to existing token extractors to cover edge cases, and to not take into account invalid tokens as soon as possible.

refs:

- https://github.com/dunglas/mercure/pull/655
- https://github.com/dunglas/mercure/issues/387
