### PR TITLE
Fix: Remove /bin from export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,6 @@
 * text=auto
 
 /.github export-ignore
-/bin export-ignore
 /config export-ignore
 /tests export-ignore
 /var export-ignore


### PR DESCRIPTION
When performing a `composer create-project freddie/mercure-x`, `bin/freddie` disappears and is replaced by a standard `bin/console`.

Looks like the `bin` folder was added to `export-ignore` by accident.