### PR TITLE
Fix: Shutdown hub when transport is gone

### DIFF
--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -72,7 +72,7 @@ jobs:
       matrix:
         transport:
           - "php://localhost?size=10000"
-          - "redis://localhost?size=10000&trimInterval=0.5"
+          - "redis://localhost?size=10000&trimInterval=0.5&pingInterval=0"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/app.yml
+++ b/.github/workflows/app.yml
@@ -73,6 +73,8 @@ jobs:
         transport:
           - "php://localhost?size=10000"
           - "redis://localhost?size=10000&trimInterval=0.5&pingInterval=0"
+          - "redis://localhost?size=10000&trimInterval=0.5&pingInterval=0.1"
+          - "redis://localhost?size=10000&trimInterval=0.5&pingInterval=0.1&readTimeout=2"
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ To launch the hub with the Redis transport, change the `TRANSPORT_DSN` environme
 TRANSPORT_DSN="redis://127.0.0.1:6379" ./bin/freddie
 ```
 
+Optional parameters you can pass in the DSN's query string:
+- `pingInterval` - regularly ping Redis connection, which will help detect outages (default `2.0`)
+- `readTimeout` - max duration in seconds of a ping or publish request (default `null`)
+
 _Alternatively, you can set this variable into `.env.local`._
 
 ## Advantages and limitations

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ TRANSPORT_DSN="redis://127.0.0.1:6379" ./bin/freddie
 
 Optional parameters you can pass in the DSN's query string:
 - `pingInterval` - regularly ping Redis connection, which will help detect outages (default `2.0`)
-- `readTimeout` - max duration in seconds of a ping or publish request (default `null`)
+- `readTimeout` - max duration in seconds of a ping or publish request (default `0.0`: considered disabled)
 
 _Alternatively, you can set this variable into `.env.local`._
 

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "nyholm/dsn": "^2.0",
         "phpdocumentor/reflection-docblock": "^5.3",
         "react/async": "^4.0.0",
+        "react/promise-timer": "^1.10",
         "rize/uri-template": "^0.3.4",
         "symfony/console": "^5.4.0|^6.0.0",
         "symfony/dotenv": "^5.4.0|^6.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eeba0dba7917b1e895df84333d9ff56f",
+    "content-hash": "24e81b3c078bb0ca6b90b4f661d16fd2",
     "packages": [
         {
             "name": "bentools/querystring",
@@ -1790,16 +1790,16 @@
         },
         {
             "name": "react/promise-timer",
-            "version": "v1.9.0",
+            "version": "v1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/promise-timer.git",
-                "reference": "aa7a73c74b8d8c0f622f5982ff7b0351bc29e495"
+                "reference": "4cb85c1c2125390748e3908120bb82feb99fe766"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise-timer/zipball/aa7a73c74b8d8c0f622f5982ff7b0351bc29e495",
-                "reference": "aa7a73c74b8d8c0f622f5982ff7b0351bc29e495",
+                "url": "https://api.github.com/repos/reactphp/promise-timer/zipball/4cb85c1c2125390748e3908120bb82feb99fe766",
+                "reference": "4cb85c1c2125390748e3908120bb82feb99fe766",
                 "shasum": ""
             },
             "require": {
@@ -1808,7 +1808,7 @@
                 "react/promise": "^3.0 || ^2.7.0 || ^1.2.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35"
             },
             "type": "library",
             "autoload": {
@@ -1857,19 +1857,15 @@
             ],
             "support": {
                 "issues": "https://github.com/reactphp/promise-timer/issues",
-                "source": "https://github.com/reactphp/promise-timer/tree/v1.9.0"
+                "source": "https://github.com/reactphp/promise-timer/tree/v1.10.0"
             },
             "funding": [
                 {
-                    "url": "https://github.com/WyriHaximus",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/clue",
-                    "type": "github"
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
                 }
             ],
-            "time": "2022-06-13T13:41:03+00:00"
+            "time": "2023-07-20T15:40:28+00:00"
         },
         {
             "name": "react/socket",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,3 +5,5 @@ parameters:
 
     ignoreErrors:
         - '#React\\Promise\\PromiseInterface is not generic#'
+        - '#Unable to resolve the template type T in call to function React\\Promise\\Timer\\timeout#'
+        - '#Unable to resolve the template type T in call to function Freddie\\maybeTimeout#'

--- a/src/Hub/Controller/PublishController.php
+++ b/src/Hub/Controller/PublishController.php
@@ -72,13 +72,11 @@ final class PublishController implements HubControllerInterface
             throw new AccessDeniedHttpException('Your rights are not sufficient to publish this update.');
         }
 
-        // @codeCoverageIgnoreStart
         try {
             await($this->hub->publish($update));
         } catch (Throwable) {
             throw new ServiceUnavailableHttpException();
         }
-        // @codeCoverageIgnoreEnd
 
         return new Response(201, body: (string) $update->message->id);
     }

--- a/src/Hub/Controller/PublishController.php
+++ b/src/Hub/Controller/PublishController.php
@@ -72,11 +72,13 @@ final class PublishController implements HubControllerInterface
             throw new AccessDeniedHttpException('Your rights are not sufficient to publish this update.');
         }
 
+        // @codeCoverageIgnoreStart
         try {
             await($this->hub->publish($update));
         } catch (Throwable) {
             throw new ServiceUnavailableHttpException();
         }
+        // @codeCoverageIgnoreEnd
 
         return new Response(201, body: (string) $update->message->id);
     }

--- a/src/Hub/Hub.php
+++ b/src/Hub/Hub.php
@@ -15,6 +15,7 @@ use InvalidArgumentException;
 use React\EventLoop\Loop;
 use React\Promise\PromiseInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Throwable;
 
 use function array_key_exists;
 use function sprintf;
@@ -98,5 +99,15 @@ final class Hub implements HubInterface
         }
 
         return $this->options[$name];
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    public static function die(Throwable $e): never
+    {
+        Loop::stop();
+
+        throw $e;
     }
 }

--- a/src/Hub/Hub.php
+++ b/src/Hub/Hub.php
@@ -101,9 +101,6 @@ final class Hub implements HubInterface
         return $this->options[$name];
     }
 
-    /**
-     * @codeCoverageIgnore
-     */
     public static function die(Throwable $e): never
     {
         Loop::stop();

--- a/src/Hub/Transport/Redis/RedisTransport.php
+++ b/src/Hub/Transport/Redis/RedisTransport.php
@@ -44,7 +44,7 @@ final class RedisTransport implements TransportInterface
             'channel' => 'mercure',
             'key' => 'mercureUpdates',
             'pingInterval' => 2.0,
-            'readTimeout' => null,
+            'readTimeout' => 0.0,
         ]);
         $this->options = $resolver->resolve($options);
         if ($this->options['pingInterval']) {

--- a/src/Hub/Transport/Redis/RedisTransport.php
+++ b/src/Hub/Transport/Redis/RedisTransport.php
@@ -13,6 +13,7 @@ use Freddie\Message\Update;
 use Generator;
 use React\EventLoop\Loop;
 use React\Promise\PromiseInterface;
+use RuntimeException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Throwable;
 
@@ -59,7 +60,7 @@ final class RedisTransport implements TransportInterface
         try {
             await($this->redis->ping()); // @phpstan-ignore-line
         } catch (Throwable) {
-            Hub::die(new \RuntimeException('Redis connection closed unexpectedly.'));
+            Hub::die(new RuntimeException('Redis connection closed unexpectedly.'));
         }
     }
 

--- a/src/Hub/Transport/Redis/RedisTransport.php
+++ b/src/Hub/Transport/Redis/RedisTransport.php
@@ -57,11 +57,11 @@ final class RedisTransport implements TransportInterface
      */
     private function ping(): void
     {
-        try {
-            await($this->redis->ping()); // @phpstan-ignore-line
-        } catch (Throwable) {
-            Hub::die(new RuntimeException('Redis connection closed unexpectedly.'));
-        }
+        /** @var PromiseInterface $ping */
+        $ping = $this->redis->ping(); // @phpstan-ignore-line
+        $ping->then(
+            onRejected: Hub::die(...),
+        );
     }
 
     public function subscribe(callable $callback): void

--- a/src/Hub/Transport/Redis/RedisTransportFactory.php
+++ b/src/Hub/Transport/Redis/RedisTransportFactory.php
@@ -38,6 +38,7 @@ final class RedisTransportFactory implements TransportFactoryInterface
             options: [
                 'size' => (int) max(0, $parsed->getParameter('size', 0)),
                 'trimInterval' => (float) max(0, $parsed->getParameter('trimInterval', 0.0)),
+                'pingInterval' => (float) max(0, $parsed->getParameter('pingInterval', 2.0)),
                 'channel' => (string) $parsed->getParameter('channel', 'mercure'),
                 'key' => (string) $parsed->getParameter('key', 'mercureUpdates'),
             ],

--- a/src/Hub/Transport/Redis/RedisTransportFactory.php
+++ b/src/Hub/Transport/Redis/RedisTransportFactory.php
@@ -39,6 +39,7 @@ final class RedisTransportFactory implements TransportFactoryInterface
                 'size' => (int) max(0, $parsed->getParameter('size', 0)),
                 'trimInterval' => (float) max(0, $parsed->getParameter('trimInterval', 0.0)),
                 'pingInterval' => (float) max(0, $parsed->getParameter('pingInterval', 2.0)),
+                'readTimeout' => (float) max(0, $parsed->getParameter('readTimeout', 0.0)),
                 'channel' => (string) $parsed->getParameter('channel', 'mercure'),
                 'key' => (string) $parsed->getParameter('key', 'mercureUpdates'),
             ],

--- a/src/functions.php
+++ b/src/functions.php
@@ -61,7 +61,7 @@ function extract_last_event_id(ServerRequestInterface $request): ?string
  * @param PromiseInterface<T> $promise
  * @return PromiseInterface<T>
  */
-function maybeTimeout(PromiseInterface $promise, ?float $time = null): PromiseInterface
+function maybeTimeout(PromiseInterface $promise, float $time = 0.0): PromiseInterface
 {
-    return null === $time ? $promise : timeout($promise, $time);
+    return 0.0 === $time ? $promise : timeout($promise, $time);
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -7,10 +7,12 @@ namespace Freddie;
 use Freddie\Helper\FlatQueryParser;
 use Freddie\Helper\TopicHelper;
 use Psr\Http\Message\ServerRequestInterface;
+use React\Promise\PromiseInterface;
 
 use function BenTools\QueryString\query_string;
 use function in_array;
 use function is_string;
+use function React\Promise\Timer\timeout;
 use function settype;
 use function strtolower;
 use function trim;
@@ -52,4 +54,14 @@ function extract_last_event_id(ServerRequestInterface $request): ?string
         ?? $qs->getParam('last-event-id')
         ?? $qs->getParam('LAST-EVENT-ID')
         ?? null;
+}
+
+/**
+ * @template T
+ * @param PromiseInterface<T> $promise
+ * @return PromiseInterface<T>
+ */
+function maybeTimeout(PromiseInterface $promise, ?float $time = null): PromiseInterface
+{
+    return null === $time ? $promise : timeout($promise, $time);
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -57,6 +57,7 @@ function extract_last_event_id(ServerRequestInterface $request): ?string
 }
 
 /**
+ * @internal
  * @template T
  * @param PromiseInterface<T> $promise
  * @return PromiseInterface<T>

--- a/tests/Unit/Hub/Controller/PublishControllerTest.php
+++ b/tests/Unit/Hub/Controller/PublishControllerTest.php
@@ -4,26 +4,33 @@ declare(strict_types=1);
 
 namespace Freddie\Tests\Unit\Hub\Controller;
 
+use Fig\Http\Message\StatusCodeInterface;
 use FrameworkX\App;
 use Freddie\Hub\Controller\PublishController;
 use Freddie\Hub\Hub;
 use Freddie\Hub\Middleware\HttpExceptionConverterMiddleware;
 use Freddie\Hub\Middleware\TokenExtractorMiddleware;
 use Freddie\Hub\Transport\PHP\PHPTransport;
+use Freddie\Hub\Transport\TransportInterface;
 use Freddie\Message\Message;
 use Freddie\Message\Update;
+use Generator;
 use Psr\Http\Message\ResponseInterface;
 use React\Http\Message\Response;
 use React\Http\Message\ServerRequest;
+use React\Promise\PromiseInterface;
 use ReflectionClass;
+use RuntimeException;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Uid\Ulid;
 
+use function expect;
 use function Freddie\Tests\create_jwt;
 use function Freddie\Tests\handle;
 use function Freddie\Tests\jwt_config;
 use function Freddie\Tests\with_token;
+use function React\Promise\reject;
 
 it('publishes updates to the hub', function (
     string $payload,
@@ -203,3 +210,52 @@ it('yells when update cannot be published', function () {
     AccessDeniedHttpException::class,
     'Your rights are not sufficient to publish this update.'
 );
+
+it('throws a service unavailable exception when publishing fails', function () {
+    $transport = new class implements TransportInterface {
+        public function publish(Update $update): PromiseInterface
+        {
+            return reject(new RuntimeException('☠️'));
+        }
+
+        public function subscribe(callable $callback): void
+        {
+        }
+
+        public function unsubscribe(callable $callback): void
+        {
+        }
+
+        public function reconciliate(string $lastEventID): Generator
+        {
+        }
+    };
+    $controller = new PublishController();
+    $app = new App(
+        new TokenExtractorMiddleware(
+            jwt_config()->parser(),
+            jwt_config()->validator(),
+        ),
+        new HttpExceptionConverterMiddleware(),
+        $controller,
+    );
+    $hub = new Hub($app, $transport);
+    $controller->setHub($hub);
+
+    // Given
+    $jwt = create_jwt(['mercure' => ['publish' => ['*']]]);
+    $request = new ServerRequest(
+        'POST',
+        '/.well-known/mercure',
+        [
+            'Authorization' => "Bearer $jwt",
+            'Content-Type' => 'application/x-www-form-urlencoded',
+        ],
+        body: 'topic=/foo&topic=/bar&data=foobar&private=true&id=' . Ulid::generate(),
+    );
+
+    // When
+    $response = handle($app, $request);
+    expect($response->getStatusCode())->toBe(StatusCodeInterface::STATUS_SERVICE_UNAVAILABLE)
+    ->and((string) $response->getBody())->toBeEmpty();
+});

--- a/tests/Unit/Hub/Controller/PublishControllerTest.php
+++ b/tests/Unit/Hub/Controller/PublishControllerTest.php
@@ -25,7 +25,6 @@ use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Uid\Ulid;
 
-use function expect;
 use function Freddie\Tests\create_jwt;
 use function Freddie\Tests\handle;
 use function Freddie\Tests\jwt_config;
@@ -256,6 +255,8 @@ it('throws a service unavailable exception when publishing fails', function () {
 
     // When
     $response = handle($app, $request);
+
+    // Then
     expect($response->getStatusCode())->toBe(StatusCodeInterface::STATUS_SERVICE_UNAVAILABLE)
-    ->and((string) $response->getBody())->toBeEmpty();
+        ->and((string) $response->getBody())->toBeEmpty();
 });

--- a/tests/Unit/Hub/HubTest.php
+++ b/tests/Unit/Hub/HubTest.php
@@ -11,7 +11,9 @@ use Freddie\Message\Update;
 use Freddie\Subscription\Subscriber;
 use Generator;
 use InvalidArgumentException;
+use React\EventLoop\Loop;
 use React\Promise\PromiseInterface;
+use RuntimeException;
 use Symfony\Component\Uid\Ulid;
 
 use function func_get_args;
@@ -70,3 +72,7 @@ it('complains when requesting an unrecognized option', function () {
     $hub = new Hub();
     $hub->getOption('foo');
 })->throws(InvalidArgumentException::class, 'Invalid option `foo`.');
+
+it('dies', function () {
+    Hub::die(new RuntimeException('😵'));
+})->throws(RuntimeException::class, '😵');


### PR DESCRIPTION
Fix #24 - Hub is not aware of redis connection losses

- Introduces a regular ping to Redis connection
- Whenever a ping fails, kill the hub

Unfortunately I was not able to set up an automatic reconnection.
Updates can be prevented from being published by returning a 503 error, but for subscriptions, I could not manage to :
- Stop the SSE
- Make it aware of a new redis connection

Killing the hub is the best I can do so far - a supervisor process (systemd, supervisor etc) should handle its respawn.