### PR TITLE
Fix/detect connection outages

### DIFF
--- a/src/Hub/Transport/Redis/RedisTransport.php
+++ b/src/Hub/Transport/Redis/RedisTransport.php
@@ -13,6 +13,7 @@ use Freddie\Message\Update;
 use Generator;
 use React\EventLoop\Loop;
 use React\Promise\PromiseInterface;
+use RuntimeException;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 use function Freddie\maybeTimeout;
@@ -50,6 +51,7 @@ final class RedisTransport implements TransportInterface
         if ($this->options['pingInterval']) {
             Loop::addPeriodicTimer($this->options['pingInterval'], fn () => $this->ping());
         }
+        $this->subscriber->on('unsubscribe', fn () => Hub::die(new RuntimeException('Redis connection lost')));
     }
 
     /**

--- a/src/Hub/Transport/Redis/RedisTransport.php
+++ b/src/Hub/Transport/Redis/RedisTransport.php
@@ -49,6 +49,7 @@ final class RedisTransport implements TransportInterface
         ]);
         $this->options = $resolver->resolve($options);
         if ($this->options['pingInterval']) {
+            $this->ping();
             Loop::addPeriodicTimer($this->options['pingInterval'], fn () => $this->ping());
         }
         $this->subscriber->on('unsubscribe', fn () => Hub::die(new RuntimeException('Redis connection lost')));

--- a/tests/Unit/Hub/Transport/Redis/RedisTransportFactoryTest.php
+++ b/tests/Unit/Hub/Transport/Redis/RedisTransportFactoryTest.php
@@ -13,7 +13,7 @@ it('supports Redis DSNs', function (string $dsn, bool $expected) {
     $factory = new RedisTransportFactory();
     expect($factory->supports($dsn))->toBe($expected);
 })->with(function () {
-    yield ['redis://localhost', true];
+    yield ['redis://localhost?pingInterval=0.0', true];
     yield ['rediss://some.secure.place.com', true];
     yield ['notredis://shrug', false];
 });
@@ -23,21 +23,22 @@ it('instantiates a Redis transport', function (string $dsn, RedisTransport $expe
     expect($factory->create($dsn))->toEqual($expected);
 })->with(function () {
     $redisFactory = new Factory();
-    yield ['redis://localhost?foo=bar', new RedisTransport(
-        $redisFactory->createLazyClient('redis://localhost?foo=bar'),
-        $redisFactory->createLazyClient('redis://localhost?foo=bar'),
+    yield ['redis://localhost?foo=bar&pingInterval=0.0', new RedisTransport(
+        $redisFactory->createLazyClient('redis://localhost?foo=bar&pingInterval=0.0'),
+        $redisFactory->createLazyClient('redis://localhost?foo=bar&pingInterval=0.0'),
+        options: ['pingInterval' => 0.0],
     )];
-    yield ['redis://localhost?size=1000&trimInterval=2.5', new RedisTransport(
-        $redisFactory->createLazyClient('redis://localhost?size=1000&trimInterval=2.5'),
-        $redisFactory->createLazyClient('redis://localhost?size=1000&trimInterval=2.5'),
-        options: ['size' => 1000, 'trimInterval' => 2.5],
+    yield ['redis://localhost?size=1000&trimInterval=2.5&pingInterval=0.0', new RedisTransport(
+        $redisFactory->createLazyClient('redis://localhost?size=1000&trimInterval=2.5&pingInterval=0.0'),
+        $redisFactory->createLazyClient('redis://localhost?size=1000&trimInterval=2.5&pingInterval=0.0'),
+        options: ['size' => 1000, 'trimInterval' => 2.5, 'pingInterval' => 0.0],
     )];
 });
 
 it('instantiates 2 different clients', function () {
     $factory = new RedisTransportFactory();
     /** @var RedisTransport $transport */
-    $transport = $factory->create('redis://localhost?size=1000');
+    $transport = $factory->create('redis://localhost?size=1000&pingInterval=0.0');
     expect($transport->redis)->toBeInstanceOf(Client::class);
     expect($transport->subscriber)->toBeInstanceOf(Client::class);
     expect($transport->redis)->not()->toBe($transport->subscriber);

--- a/tests/Unit/Hub/Transport/Redis/RedisTransportTest.php
+++ b/tests/Unit/Hub/Transport/Redis/RedisTransportTest.php
@@ -16,7 +16,8 @@ it('dispatches published updates', function () {
     $eventEmitter = new EventEmitter();
     $transport = new RedisTransport(
         new RedisClientStub($storage, $eventEmitter),
-        new RedisClientStub($storage, $eventEmitter)
+        new RedisClientStub($storage, $eventEmitter),
+        options: ['pingInterval' => 0.0],
     );
 
     // Given
@@ -40,7 +41,7 @@ it('dispatches published updates', function () {
 
 it('performs state reconciliation', function () {
     $client = new RedisClientStub();
-    $transport = new RedisTransport($client, clone $client, options: ['size' => 3]);
+    $transport = new RedisTransport($client, clone $client, options: ['pingInterval' => 0.0, 'size' => 3]);
 
     // Given
     $updates = [
@@ -81,7 +82,11 @@ it('performs state reconciliation', function () {
 
 it('periodically trims the database', function () {
     $client = new RedisClientStub();
-    $transport = new RedisTransport($client, clone $client, options: ['size' => 3, 'trimInterval' => 0.01]);
+    $transport = new RedisTransport($client, clone $client, options: [
+        'pingInterval' => 0.0,
+        'size' => 3,
+        'trimInterval' => 0.01
+    ]);
 
     // Given
     $updates = [


### PR DESCRIPTION
Replaces #28 in a safer/cleaner way, following advices from https://github.com/clue/reactphp-redis/issues/142#issuecomment-1999742302

What it does:

- When `ping_interval` is positive, immediately ping connection before `$transport->subscribe()` is invoked. Reduces the risk of starting the hub with a broken redis link
- Listen to the `unsubscribe` event and trigger a hub crash so that its supervisor can handle its respawn. I initially thought that `unsubscribe` wouldn't be safe (like a subscriber just closing the connection) but it looks it would only be triggered in the case of a lost connection, since Freddie never calls `$client->unsubscribe()`.

cc @misaert:

With both `ping_interval` enabled and that small addition, the EventSource was always able to recover its connection to the hub once Redis was back on again (during my tests). Can you please give this one a try?

Thanks @SimonFrings for the tip!