### PR TITLE
Chore: Fix deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
         "pestphp/pest": "^1.21",
         "phpstan/phpstan": "^1.2",
         "react/child-process": "^0.6.4",
+        "ringcentral/psr7": "^1.3",
         "squizlabs/php_codesniffer": "^3.6",
         "symfony/http-client": "^5.4.0|^6.0.0|^7.0.0",
         "symfony/process": "^5.4.0|^6.0.0|^7.0.0"

--- a/symfony.lock
+++ b/symfony.lock
@@ -169,9 +169,6 @@
     "react/stream": {
         "version": "v1.2.0"
     },
-    "ringcentral/psr7": {
-        "version": "1.3.0"
-    },
     "rize/uri-template": {
         "version": "0.3.4"
     },


### PR DESCRIPTION
Add `ringcentral/psr7` in `require-dev` as it's no longer a ReactPHP dependency